### PR TITLE
Update URL to docs on 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,4 @@ The Adonis slim app is the tinest boilerplate to create Adonisjs applications wi
 
 This project structure can scale as you go, simply execute the `ace` commands to create **Controllers**, **Models**, etc for you. 
 
-Also make sure to read the
-[guides](http://dev.adonisjs.com/docs/4.0/installation)
+Also make sure to read the [guides](http://dev.adonisjs.com/docs/4.0/installation)

--- a/README.md
+++ b/README.md
@@ -6,4 +6,5 @@ The Adonis slim app is the tinest boilerplate to create Adonisjs applications wi
 
 This project structure can scale as you go, simply execute the `ace` commands to create **Controllers**, **Models**, etc for you. 
 
-Also make sure to read the [guides](http://adonisjs.com/guides)
+Also make sure to read the
+[guides](http://dev.adonisjs.com/docs/4.0/installation)


### PR DESCRIPTION
Currently the URL goes to 404 on the old site. 

I know that the current new site is still on dev subdomain, but still nice to have a working link when creating a new project and clicking a link to read the docs.