### PR TITLE
Remove invalid apostrophe

### DIFF
--- a/start/routes.js
+++ b/start/routes.js
@@ -6,7 +6,7 @@
 |--------------------------------------------------------------------------
 |
 | Http routes are entry points to your web application. You can create
-| routes for different URL's and bind Controller actions to them.
+| routes for different URLs and bind Controller actions to them.
 |
 | A complete guide on routing is available here.
 | http://adonisjs.com/guides/routing


### PR DESCRIPTION
Apostrophe is meant to show contraction or possession. In this case, it is being used to show plural.