### PR TITLE
Update hash.js to avoid ReferenceError

### DIFF
--- a/config/hash.js
+++ b/config/hash.js
@@ -1,4 +1,5 @@
 'use strict'
+const Env = use('Env')
 
 module.exports = {
   /*


### PR DESCRIPTION
adding const Env = use('Env') to avoid ReferenceError: Env is not defined error